### PR TITLE
add batch-module dependency in plume-mail project

### DIFF
--- a/plume-framework-dependencies/pom.xml
+++ b/plume-framework-dependencies/pom.xml
@@ -137,6 +137,11 @@
 				<version>${simple-java-mail.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.simplejavamail</groupId>
+				<artifactId>batch-module</artifactId>
+				<version>${simple-java-mail.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>

--- a/plume-mail/pom.xml
+++ b/plume-mail/pom.xml
@@ -22,6 +22,10 @@
 			<groupId>org.simplejavamail</groupId>
 			<artifactId>simple-java-mail</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.simplejavamail</groupId>
+			<artifactId>batch-module</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.google.inject</groupId>


### PR DESCRIPTION
Fixing issue: Batch module not found, make sure it is on the classpath (https://github.com/bbottema/simple-java-mail/tree/develop/modules/batch-module)