### PR TITLE
Doc : Add scheduler field

### DIFF
--- a/plume-scheduler/README.md
+++ b/plume-scheduler/README.md
@@ -24,11 +24,13 @@ Create a `ScheduledJobs` class:
 @Singleton
 public class ScheduledJobs {
 
+    private final Scheduler scheduler;
     private final MyService service1;
     private final MyOtherService service2;
 
     @Inject
     public ScheduledJobs(Scheduler scheduler, MyService service1, MyOtherService service2) {
+        this.scheduler = scheduler;
         this.service1 = service1;
         this.service2 = service2;
     }


### PR DESCRIPTION
Quick-fix proposal for the [documentation of plume-scheduler](https://github.com/Coreoz/Plume/blob/master/plume-scheduler/README.md) : 

Injected `scheduler` field should be a member of class.